### PR TITLE
Question Text Wrap

### DIFF
--- a/app-steady/app-steady/GraphicalTableViewCell.swift
+++ b/app-steady/app-steady/GraphicalTableViewCell.swift
@@ -68,6 +68,7 @@ class GraphicalTableViewCell: UITableViewCell {
         questionLabel.backgroundColor = COLOR_TINT
         questionLabel.font = UIFont(name: FONT_MEDIUM, size: 20.0)
         questionLabel.textAlignment = NSTextAlignment.Center
+        questionLabel.numberOfLines = 0
         questionLabel.translatesAutoresizingMaskIntoConstraints = false
         
         self.addSubview(lineChart)
@@ -111,7 +112,7 @@ class GraphicalTableViewCell: UITableViewCell {
         allConstraints += horizontalQuestionLabelConstraints
         
         let verticalQuestionLabelConstraints = NSLayoutConstraint.constraintsWithVisualFormat(
-            "V:|[questionLabel(40)]",
+            "V:|[questionLabel(55)]",
             options: [],
             metrics: nil,
             views: viewsFromTheSix)


### PR DESCRIPTION
## Summary

Increased the vertical padding for the question text blocks by 15 points from 40 to 55 to allow for 2 lines of text
- Just an aesthetic change that is one solution for the issue
- Tested on 4, 5, 6, 6+
